### PR TITLE
fix: Add missing address column header to trade history table

### DIFF
--- a/index.html
+++ b/index.html
@@ -151,6 +151,7 @@
                     <th>Price</th>
                     <th>Amount</th>
                     <th>Value</th>
+                    <th>Address</th>
                 </tr>
             </thead>
             <tbody id="trade-history-body">


### PR DESCRIPTION
## Description
Added the missing "Address" column header to the trade history table to ensure proper table header alignment across all columns.

## Changes Made
- Added `<th>Address</th>` to the table header row in index.html
- Verified the change locally using Python's HTTP server

## Testing
- Manually verified table header alignment in browser
- Confirmed no breaking changes to existing functionality